### PR TITLE
Actions のキャッシュを正しくリストアする

### DIFF
--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -36,7 +36,7 @@ jobs:
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
   
-      - name: Cache JavaScript modules
+      - name: Cache Yarn cache directory
         uses: actions/cache@v1
         id: yarn-cache
         with:

--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -20,6 +20,11 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
+      - name: Set up Ruby 2.7
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.7.0
+
       - name: Cache gems
         uses: actions/cache@v1
         with:
@@ -27,10 +32,17 @@ jobs:
           key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
           restore-keys: ${{ runner.os }}-gems-
 
-      - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+  
+      - name: Cache JavaScript modules
+        uses: actions/cache@v1
+        id: yarn-cache
         with:
-          ruby-version: 2.7.0
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
 
       - uses: borales/actions-yarn@v2.0.0
         with:

--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -20,10 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - uses: actions/cache@v1
+      - name: Cache gems
+        uses: actions/cache@v1
         with:
           path: vendor/bundle
-          key: bundle-${{ hashFiles('**/Gemfile.lock') }}
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: ${{ runner.os }}-gems-
 
       - name: Set up Ruby 2.7
         uses: actions/setup-ruby@v1
@@ -41,7 +43,9 @@ jobs:
         run: sudo apt-get install libpq-dev
 
       - name: Bundle install
-        run: bundle install --jobs 4 --retry 3
+        run: |
+          bundle config path vendor/bundle
+          bundle install --jobs 4 --retry 3
 
       - name: Setup Database
         run: |

--- a/.github/workflows/rails-ci.yml
+++ b/.github/workflows/rails-ci.yml
@@ -71,7 +71,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
 
       - name: Rubocop
-        run: bundle exec rubocop
+        run: bundle exec rubocop -c .rubocop.yml
 
       - name: RSpec
         run: COVERAGE=true bundle exec rspec  --require rails_helper

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ yarn-debug.log*
 .generators
 .idea/
 .rakeTasks
+/vendor/*

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - bin/**/*
     - db/schema.rb
+    - vendor/**/*
     - node_modules/**/*
 
   DisplayCopNames: true


### PR DESCRIPTION
# 目的

#14 の課題解決 + α

# 影響範囲

`$ git push` 時の `rubocop` と `RSpec` の動作

## 変更ファイル

- `.github/workflows/rails-ci.yml`
- `.gitignore`
- `.rubocop.yml`

[エビデンス](https://github.com/KeisukeKudo/sharetil/actions)

# やったこと

## Ruby Gem のキャッシュ/リストア

- キャッシュリストア設定を追加
  - Ruby Gem のキャッシュキーを修正
- `bundle install` でインストールされる `gem` の保存先を `vendor/bundle` に変更
- `.rubocop.yml` が `vendor/bundle` のものを見るようになってしまったので､ルートディレクトリの `yml` を見るよう指定
- `.rubocop.yml` に `vendor` 直下を解析対象外にする設定を追記

## yarn cache ディレクトリのキャッシュ/リストア

`$ yarn cache dir` で出力されるパスをキャッシュ対象に設定
それ以外は gem とほぼ同様

## vendor 直下を Git 管理外に設定